### PR TITLE
Update Grock runtime to 46 and more

### DIFF
--- a/me.leucoso.Grock.json
+++ b/me.leucoso.Grock.json
@@ -1,7 +1,7 @@
 {
     "app-id": "me.leucoso.Grock",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "grock",
     "finish-args": [

--- a/me.leucoso.Grock.json
+++ b/me.leucoso.Grock.json
@@ -14,12 +14,18 @@
     ],
     "cleanup": [
         "/include",
+        "/lib/cmake",
+        "/lib/girepository-1.0",
         "/lib/pkgconfig",
+        "/libexec",
         "/man",
         "/share/doc",
+        "/share/gir-1.0",
         "/share/gtk-doc",
+        "/share/installed-tests",
         "/share/man",
         "/share/pkgconfig",
+        "/share/vala",
         "*.la",
         "*.a"
     ],


### PR DESCRIPTION
### Update Grock runtime to 46

- Update Grock runtime to 46

### experimental: Reduce package size

- Reduce package size removing some redundant files.